### PR TITLE
CpuInstructionSharedBinaryBinaryFunctionAdc decimal mode carry flag n…

### DIFF
--- a/src/main/java/walkingkooka/emulator/c64/CpuInstructionSharedBinaryFunction.java
+++ b/src/main/java/walkingkooka/emulator/c64/CpuInstructionSharedBinaryFunction.java
@@ -48,7 +48,6 @@ abstract class CpuInstructionSharedBinaryFunction {
                          final byte right,
                          final CpuContext context);
 
-
     final int units(final byte value) {
         return 0x0f & value;
     }

--- a/src/main/java/walkingkooka/emulator/c64/CpuInstructionSharedBinaryFunctionAdc.java
+++ b/src/main/java/walkingkooka/emulator/c64/CpuInstructionSharedBinaryFunctionAdc.java
@@ -156,7 +156,7 @@ final class CpuInstructionSharedBinaryFunctionAdc extends CpuInstructionSharedBi
                             final CpuContext context) {
         final int value = (0xff & left) +
             (0xff & right) +
-            (context.isCarry() ? 1 : 0);
+            carryToUnit(context);
 
         final byte byteValue = (byte) value;
 
@@ -184,7 +184,7 @@ final class CpuInstructionSharedBinaryFunctionAdc extends CpuInstructionSharedBi
     private byte decimalMode(final byte left,
                              final byte right,
                              final CpuContext context) {
-        int units = units(left) + units(right); // ignore carry
+        int units = units(left) + units(right) + carryToUnit(context);
         if (units > 9) {
             units = units + 6;
         }
@@ -214,5 +214,11 @@ final class CpuInstructionSharedBinaryFunctionAdc extends CpuInstructionSharedBi
         context.setOverflow(false); // never sets overflow, always clears
 
         return byteValue;
+    }
+
+    private static int carryToUnit(final CpuContext context) {
+        return context.isCarry() ?
+            1 :
+            0;
     }
 }

--- a/src/test/java/walkingkooka/emulator/c64/CpuInstructionSharedBinaryFunctionAdcTest.java
+++ b/src/test/java/walkingkooka/emulator/c64/CpuInstructionSharedBinaryFunctionAdcTest.java
@@ -105,9 +105,20 @@ public final class CpuInstructionSharedBinaryFunctionAdcTest extends CpuInstruct
         this.handleAndCheck(
             (byte) 0x0,
             (byte) 0x0,
-            "C--D-1VN",
+            "---D-1VN",
             (byte) 0,
             "-Z-D-1--"
+        );
+    }
+
+    @Test
+    public void testHandleDecimalZeroWithCarry() {
+        this.handleAndCheck(
+            (byte) 0x0,
+            (byte) 0x0,
+            "C--D-1VN",
+            (byte) 1,
+            "---D-1--"
         );
     }
 
@@ -129,6 +140,17 @@ public final class CpuInstructionSharedBinaryFunctionAdcTest extends CpuInstruct
             (byte) 0x33,
             "---D-1--",
             (byte) 0x58,
+            "---D-1--"
+        );
+    }
+
+    @Test
+    public void testHandleDecimalWithCarry() {
+        this.handleAndCheck(
+            (byte) 0x25,
+            (byte) 0x33,
+            "C--D-1--",
+            (byte) 0x59,
             "---D-1--"
         );
     }


### PR DESCRIPTION
…ot ignored FIX

- Carry flag becomes 1 (when set) or 0 (when clear).
- Previously saw a note that carry is ignored in decimal mode.